### PR TITLE
riji publish failed in some Operating systems which has case-sensitive filesystem (ex Linux)

### DIFF
--- a/lib/Riji/CLI/Publish.pm
+++ b/lib/Riji/CLI/Publish.pm
@@ -28,7 +28,7 @@ sub run {
         die "Unknown local files:\n$untracked\n\nUpdate .gitignore, or git add them\n";
     }
 
-    if (my $uncommited = $repo->run(qw/diff head --name-only/) ) {
+    if (my $uncommited = $repo->run(qw/diff HEAD --name-only/) ) {
         die "Found uncommited changes:\n$uncommited\n\ncommit them beforehand\n";
     }
 


### PR DESCRIPTION
riji publish is failed in my Linux server.  executing 'git diff head' is failed and it should be 'git diff HEAD', I think.

```
$ git diff head --name-only
fatal: ambiguous argument 'head': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

```
$ git diff HEAD --name-only

```
