### PR TITLE
Set more exact repository path if when `base_dir` is different from `repo_dir`.

### DIFF
--- a/lib/Riji/Model/Entry.pm
+++ b/lib/Riji/Model/Entry.pm
@@ -16,7 +16,8 @@ has repo_path => (
     lazy    => 1,
     default => sub {
         my $self = shift;
-        $self->file_path->relative($self->base_dir)
+        my $repo_dir = $self->repo->run(qw/rev-parse --show-toplevel/);
+        $self->file_path->relative($repo_dir)
     },
 );
 


### PR DESCRIPTION
Cannot get `publushd_by` now if when `base_dir` is different from `repo_dir`.
It fix this issue.
