### PR TITLE
create dir unless article/entry

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -34,4 +34,6 @@ on configure => sub {
 
 on test => sub {
     requires 'Test::More', '0.98';
+    requires 'Test::Output';
+    requires 'Scope::Guard';
 };

--- a/lib/Riji/CLI/NewEntry.pm
+++ b/lib/Riji/CLI/NewEntry.pm
@@ -13,8 +13,10 @@ sub run {
     die "subtitle: $subtitle is not valid\n" if $subtitle && $subtitle =~ /[^-_a-zA-Z0-9]/;
 
     my $now = localtime;
+    my $dir = path('article/entry');
+    $dir->mkpath unless $dir->exists;
     my $date_str = $now->strftime('%Y-%m-%d');
-    my $file_format = "article/entry/$date_str-%s.md";
+    my $file_format = "$dir/$date_str-%s.md";
     my $file;
     if ($subtitle) {
         $file = path(sprintf $file_format, $subtitle);

--- a/t/cli-new_entry.t
+++ b/t/cli-new_entry.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Output;
+use FindBin;
+use Path::Tiny;
+use Scope::Guard;
+use Riji::CLI::NewEntry;
+
+subtest 'create dir unless article/entry' => sub {
+    my $article_dir = path('article');
+
+    my $setup = do {
+        delete $ENV{EDITOR};
+
+        chdir $FindBin::Bin;
+        fail "directory already exists: $article_dir" if $article_dir->exists;
+
+        Scope::Guard->new(sub {
+            $article_dir->remove_tree({safe => 0});
+        });
+    };
+
+    stdout_like {
+        Riji::CLI::NewEntry->run;
+    } qr/\w is created. Edit it!/;
+};
+
+done_testing;


### PR DESCRIPTION
I saw http://songmu.github.io/p5-Riji/blog/entry/002_edit.html .

```
 (git)-[master]-% tree article
article
├── archives.md
├── entry
│   └── sample.md
└── index.md

 (git)-[master]-% git rm article/entry/sample.md
rm 'article/entry/sample.md'

 (git)-[master]-% git commit -m "remove sample.md"
[master 7d1e0f0] remove sample.md
 1 file changed, 1 deletion(-)
 delete mode 100644 article/entry/sample.md
```

When I ran `git rm`, git had deleted `article/entry`.

```
 (git)-[master]-% tree article
article
├── archives.md
└── index.md

0 directories, 2 files
```

So, it becomes an error to run the new-entry.

```
 (git)-[master]-% riji new-entry
Error sysopen on 'article/entry/2014-05-22-01.md960231865494009': No such file or directory at /Users/monmon/.anyenv/envs/plenv/versions/5.18/lib/perl5/site_perl/5.18.2/Riji/CLI/NewEntry.pm line 27.
```
