### PR TITLE
Fix wrong date format

### DIFF
--- a/lib/Riji/Model/Atom.pm
+++ b/lib/Riji/Model/Atom.pm
@@ -32,7 +32,7 @@ has entry_datas => (
                 pubDate     => $_->last_modified_at->epoch,
                 author      => $_->created_by,
                 guid        => $_->tag_uri->as_string,
-                published   => $_->published_at->strftime('%Y-%m-%dT%M:%M:%S%z'),
+                published   => $_->published_at->strftime('%Y-%m-%dT%H:%M:%S%z'),
                 link        => $_->url,
             } } @{ $self->blog->entries(sort_by => 'last_modified_at', limit => 20) }
         ]


### PR DESCRIPTION
I changed `%M:%M` to `%H:%M`.

Feed was broken like this.

```
% curl --silent http://www.songmu.jp/riji/atom.xml | grep published
<published>2015-01-03T52:52:14+0900</published>
<published>2014-12-31T04:04:59+0900</published>
<published>2014-12-25T00:00:41+0900</published>
<published>2014-12-24T51:51:25+0900</published>
...
```