### PR TITLE
remove DEBIAN_FRONTEND=noninteractive from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM debian:stable-slim
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    LANG=en_US.UTF-8 \
+ENV LANG=en_US.UTF-8 \
     LC_ALL=C.UTF-8 \
     LANGUAGE=en_US.UTF-8
 


### PR DESCRIPTION
It used to be that if you didn't specify this, the installation would stop halfway through waiting for input, but now it seems to be fine, so I'll cut it out.

In any case, when specifying this environment variable, it should be narrowly scoped and should not be global.